### PR TITLE
Mezzanine generation script cleanup and improvements

### DIFF
--- a/mezzanine.sh
+++ b/mezzanine.sh
@@ -1,38 +1,53 @@
 #!/bin/bash
 
+FONT="monospace"
+SEEK="00:00:00.000"
+DURATION=30
+FRAMERATE=30
+BOUNDARIES="boundaries.png"
+RESOLUTION="1920x1080"
+WIDTH=""  # Pulled from RESOLUTION string, see below
+HEIGHT="" # Pulled from RESOLUTION string, see below
+NAME="cta-wave-mezzanine"
+
 function help() {
     echo "\
 WAVE Mezzanine Content Creator
-$0 [-b <img-file>] [-s <ss-param>] [-d <duration>] [-f <framerate>] <source-file> <output-file>
+$0 [<flags>] <source-file> <output-file>
 
     -b, --boundaries <img-file>
         Specifies a file that contains boundary markers
-        Default: boundaries.png
-
-    -s, --seek <ss-param>
-        Seeks the source file to a starting position
-        Format must follow ffmpeg -ss parameter
-        Default: 0
+        Default: $BOUNDARIES
 
     -d, --duration <duration>
         The duration, in seconds, of the source file to process from the seek position in
-        Default: 30
+        Default: $DURATION
 
     -f, --framerate <framerate>
         The target framerate of the output file
         Fractional rates must be specified as division operations \"30000/1001\"
-        Default: \"00:00:30.0\"
-
-    -n, --name <string>
-        Provide a name for this mezzanine, will exist in qrcode
-        Default: \"cta-wave-mezzanine\"
-
-    -t, --font <string>
-        The font to utilize for drawing timecodes on frames, must be full path to file
-        Default: System Specified Default
+        Default: $FRAMERATE
 
     -h, --help
         Displays this help message
+
+    -n, --name <string>
+        Provide a name for this mezzanine, will exist in qrcode
+        Default: \"$NAME\"
+
+    -r, --resolution <string>
+        The target resolution of the output, video will be scaled and padded to fit resolution
+        Should be specified as \"<width>x<height>\"
+        Default: \"$RESOLUTION\"
+
+    -s, --seek <ss-param>
+        Seeks the source file to a starting position
+        Format must follow ffmpeg -ss parameter
+        Default: \"$SEEK\"
+
+    -t, --font <string>
+        The font to utilize for drawing timecodes on frames, must be full path to file
+        Default: System Specified Default for $FONT
 "
     if [[ ! -z $1 ]]; then
         echo "Error: $1"
@@ -41,23 +56,11 @@ $0 [-b <img-file>] [-s <ss-param>] [-d <duration>] [-f <framerate>] <source-file
     exit
 }
 
-FONT=""
-SEEK="00:00:00.000"
-DURATION=30
-FRAMERATE=30
-BOUNDARIES="boundaries.png"
-NAME="cta-wave-mezzanine"
-
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
     case $1 in
         -b|--boundaries)
         BOUNDARIES="$2"
-        shift
-        shift
-        ;;
-        -s|--seek)
-        SEEK="$2"
         shift
         shift
         ;;
@@ -71,8 +74,16 @@ while [[ $# -gt 0 ]]; do
         shift
         shift
         ;;
+        -h|--help)
+        help
+        ;;
         -n|--name)
         NAME="$2"
+        shift
+        shift
+        ;;
+        -r|--resolution)
+        RESOLUTION="$2"
         shift
         shift
         ;;
@@ -81,8 +92,10 @@ while [[ $# -gt 0 ]]; do
         shift
         shift
         ;;
-        -h|--help)
-        help
+        -s|--seek)
+        SEEK="$2"
+        shift
+        shift
         ;;
         *)
         POSITIONAL+=("$1")
@@ -107,10 +120,21 @@ if [[ ! -f $BOUNDARIES ]]; then
     help "Boundaries <img-file> (\"$BOUNDARIES\") does not exist"
 fi
 
+# Grab width and height from input resolution
+WIDTH=$(awk -Fx '{print $1}' <<< $RESOLUTION)
+HEIGHT=$(awk -Fx '{print $2}' <<< $RESOLUTION)
+
+if [[ -z $WIDTH ]] || [[ -z $HEIGHT ]]; then
+    help "Resolution must be form of <width>x<height>, given: \"$RESOLUTION\""
+fi
+
 # Helper for performing rounded float operations since bash cannot directly do this
 function roundedfloat {
     awk "BEGIN {printf \"%.$2f\", $1}"
 }
+
+# Compute QR size relative to output framing, target 25% frame height
+QRSIZE=`roundedfloat "$HEIGHT*0.25" 0`
 
 # Generates a series of timestamped QR codes at the framerate of the target output
 # Each QR code is generated and output to stdout
@@ -139,29 +163,48 @@ function generateqrcodes {
 #   [1] The original video source seeked to the desired point
 #   [2] An image file of frame boundary markers
 #   [3] A series of qr code images at the target framerate from stdin
+#       (thread queuing set high to avoid waiting on qr gen)
 # - Applies the following complex filter to the demuxed inputs:
 #   - Takes the video stream from the original source and:
-#       - Adds top/bottom black bars to make it 16:9
-#       - Forces the framerate to the desired framerate
+#       - Scales it to the desired output size while preserving original ratio
+#       - Adds top/bottom black bars to enforce a 16:9 frame
 #       - Fixes the output format to yuv420p
+#       - Forces the framerate to the desired framerate
 #       - Draws the timecode of the current frame onto it
-#   - Takes the modified video stream and overlays the boundary marker at full screen
-#   - Takes the video stream + overlay and overlays a qr code at alternating positions
-#  - The output of the filter is then:
-#   - Encoded in h264 and aac
+#   - Takes the boundary marker and:
+#       - Scales it to the desired output size
+#   - Takes the qr code stream and:
+#       - Scales them relative to their final positioning in the composition
+#   - Performs a series of overlay compositions
+#       - Uses the padded source as the base
+#       - Full screen overlays the scaled boundary marker
+#       - Places the QR codes in a pattern based on frame number
+#  - Post filter the output is mapped as follows:
+#   - Video is the output of the last overlay composition
+#   - Audio is directly from the beep input
+#  - The mapped outputs are then:
+#   - Encoded in h264 for video and aac for audio
+#   - Fixed to the desired output framerate
 #   - Fixed to the desired duration
-#   - Written to the supplied output location
+#   - Written to the supplied output location (overwriting is enabled)
 
 generateqrcodes | \
     ffmpeg \
         -f lavfi -i "sine=beep_factor=4" \
         -ss $SEEK -i $SOURCE \
         -i $BOUNDARIES \
-        -framerate $FRAMERATE -f image2pipe -vcodec png -i - \
-        -filter_complex " \
+        -framerate $FRAMERATE -f image2pipe -thread_queue_size 512 -vcodec png -i - \
+        -filter_complex "\
             [1:v]\
-                pad=1920:1080:0:140,\
+                scale=\
+                    size=${WIDTH}x${HEIGHT}:\
+                    force_original_aspect_ratio=decrease,\
                 setsar=1,\
+                pad=\
+                    w=$WIDTH:\
+                    h=$HEIGHT:\
+                    x=(ow-iw)/2:\
+                    y=(oh-ih)/2,\
                 format=yuv420p,\
                 fps=fps=$FRAMERATE,\
                 drawtext=\
@@ -170,25 +213,35 @@ generateqrcodes | \
                     x=(w-tw)/2:\
                     y=h-(4*lh):\
                     fontcolor=white:\
-                    fontsize=60:\
+                    fontsize=h*0.06:\
                     box=1:\
-                    boxborderw=20:\
+                    boxborderw=h*0.02:\
                     boxcolor=black\
-            [framed]; \
-            [framed][2] \
+            [content];\
+            [2]\
+                scale=\
+                    size=${WIDTH}x${HEIGHT}\
+            [boundaries];\
+            [3]\
+                scale=\
+                    w=$QRSIZE:\
+                    h=-1\
+            [qrs];\
+            [content][boundaries]\
                 overlay=\
-                    repeatlast=1 \
-            [bounded]; \
-            [bounded][3] \
+                    repeatlast=1\
+            [bounded];\
+            [bounded][qrs]\
                 overlay=\
-                    x=130: \
-                    y=320+'if(eq(mod(n,2),0),230,0)' \
-            [stamped]\
+                    x=main_w*0.1:\
+                    y='if(eq(mod(n,2),0),main_h*0.2,main_h*0.8-overlay_h)'\
+            [vfinal]\
         " \
-        -map '[stamped]' \
-        -map 0:a:0 \
+        -map '[vfinal]' \
+        -map '0:a' \
         -c:v libx264 -preset slower -crf 5 \
         -c:a aac -b:a 320k -ac 2 \
+        -r $FRAMERATE \
         -t $DURATION \
         -y \
         $OUTPUT


### PR DESCRIPTION
Made the script a bit more generic, should be able to handle arbitrary content sizing now as well.

- Cleaned up option set to mezzanine script
- Made target resolution configurable with appropriate sizing of the overlay components when this is done
- Increased cross process data queueing for qrcode -> ffmpeg
- Documented in README how to use the script